### PR TITLE
docs(spec): register §4.6 routing/context/dry-run conventions [D-57]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **§4.6 conventions table — three new `x-*` AI-routing keys (D-57).** Documentation-only registration of three metadata conventions surfaced by the 2025–2026 LLM-agent / tool-use frontier-research alignment audit:
+  - `x-reasoning-demand` (`low` | `medium` | `high`) — hint of the minimum reasoning capability the calling agent needs; consumed by upstream model routers for tier selection. Aligns with RouteLLM (ICLR 2025), xRouter (arXiv 2510.08439), and Cost-Aware Model Orchestration (arXiv 2512.01099).
+  - `x-required-context-keys` — array of `context.data` key names the module reads, enabling orchestrators to inject required state ahead of the call. Does **not** include framework-owned Context fields (`trace_id`, `caller_id`, etc.).
+  - `x-supports-dry-run` (boolean) — module-level signal that `Executor.validate()` (§12.2) is meaningful for this module.
+- **`docs/spec/2026-05-decision-log.md` — D-57 (§4.6 reasoning/context/dry-run conventions)** — marked **resolved**. Resolution status block updated to include D-57.
+
+### Notes
+
+- **No SDK behavior change.** All three SDKs (`apcore-python`, `apcore-typescript`, `apcore-rust`) treat module `metadata` as a free-form dict / `Record<string, unknown>` / `serde_json::Value`; the framework explicitly does not validate metadata content (§4.6 "Metadata Design Principles"). New `x-*` keys are additive conventions only.
+- **Strict-mode export unaffected.** §4.16 mandates that `to_strict_schema()` strips all `x-*` extension fields, so the new keys do not surface in strict-mode output.
+- **No normative MUST/MUST NOT additions.** §4.6 is the open-extension registry per `.claude/rules/protocol-spec.md` ("Do not invent x- extension fields not already listed in §4.6"); this PR registers three new conventions in the canonical landing spot.
+
+---
+
 ## [0.20.0] - 2026-05-05
 
 ### Added

--- a/PROTOCOL_SPEC.md
+++ b/PROTOCOL_SPEC.md
@@ -1078,6 +1078,23 @@ metadata:
   x-verification-hint: "Cross-check amounts with accounting.get_balance"
 ```
 
+**Routing & Verification Hints** — Help orchestrators choose the right model, inject required state, and preflight destructive calls:
+
+```yaml
+metadata:
+  # Reasoning demand: hint to upstream model routers for tier selection
+  x-reasoning-demand: medium     # one of: low | medium | high
+
+  # Context keys this module reads from context.data
+  # (does NOT include framework-owned Context fields like trace_id, caller_id)
+  x-required-context-keys:
+    - user_preferences
+    - billing_account_id
+
+  # Dry-run capability: module-level signal that Executor.validate() is meaningful
+  x-supports-dry-run: true
+```
+
 | Key | Category | Purpose |
 |-----|----------|---------|
 | `x-when-to-use` | Intent | Positive guidance: scenarios where this module is the right choice |
@@ -1093,6 +1110,9 @@ metadata:
 | `x-sla` | Performance | SLA targets (availability, latency percentiles) |
 | `x-output-source` | Trust | Data provenance: database, api, generated, cached, computed |
 | `x-verification-hint` | Trust | How to cross-check the output for correctness |
+| `x-reasoning-demand` | Routing | One of `low`/`medium`/`high`. Hint of the minimum reasoning capability the calling agent needs; consumed by upstream model routers for tier selection. |
+| `x-required-context-keys` | Planning | Array of `context.data` key names the module reads. Does **not** include framework-owned Context fields (`trace_id`, `caller_id`, etc.). |
+| `x-supports-dry-run` | Verification | Boolean. Module-level signal that `Executor.validate()` (see §12.2) is meaningful for this module — i.e., the module overrides `preflight()` and/or has no destructive side-effects pre-execute. |
 
 **Metadata Design Principles:**
 

--- a/docs/spec/2026-05-decision-log.md
+++ b/docs/spec/2026-05-decision-log.md
@@ -788,7 +788,7 @@ the same fixture file.
 
 ## Resolution status
 
-- **Resolved** (no further action): D-02, D-05, D-23, D-29, D-30, D-31, D-32, D-34, D-35, D-36, D-37, D-38, D-41, D-42, D-43, D-44, D-45, D-46, D-54, D-55, D-56
+- **Resolved** (no further action): D-02, D-05, D-23, D-29, D-30, D-31, D-32, D-34, D-35, D-36, D-37, D-38, D-41, D-42, D-43, D-44, D-45, D-46, D-54, D-55, D-56, D-57
 - **Doc-only fixes** (1-line each): D-01, D-07, D-09, D-16, D-17, D-18, D-26
 - **Code fix needed in 1 SDK**: D-04 (TS), D-08 (Python), D-10 (Python), D-11 (Python), D-12 (Python), D-13 (Python), D-14 (Rust), D-19 (Rust), D-25 (TS+Rust), D-27 (Rust), D-28 (Rust)
 - **Multi-SDK code fix**: D-03 (all 3), D-15 (Python+TS), D-24 (TS+Rust)
@@ -1009,3 +1009,28 @@ TypeScript SDK adds `OverridesStore` interface, `FileOverridesStore` (YAML-backe
 - Algorithm A04 in `docs/spec/algorithms.md` describes one canonical 8-stage pipeline; cross-language conformance no longer special-cases TS.
 
 **Status**: **resolved**. See `docs/spec/algorithms.md` Algorithm A04 (8-stage pipeline) and the existing `conformance/fixtures/multi_module_discovery.json` (no fixture change required — TS now follows the canonical shape).
+
+---
+
+## D-57 — §4.6 reasoning / context / dry-run conventions
+
+**Status quo (pre-resolution)**
+- The 2025–2026 LLM-agent / cognitive-architecture / tool-use frontier-research alignment audit identified three signals not covered by the 18 existing `x-*` conventions in §4.6:
+  - **Reasoning load** for upstream model routers (RouteLLM ICLR 2025, xRouter arXiv 2510.08439, Cost-Aware Model Orchestration arXiv 2512.01099 all consume per-tool reasoning hints; apcore had nothing to expose).
+  - **Required state** the module reads from `context.data` (orchestrators / `apcore-mcp` bridges currently have no standard way to pre-fetch and inject the right keys).
+  - **Module-level dry-run capability** (existing per-step `pure: bool` metadata governs the pipeline, but no module-level signal told the caller whether `Executor.validate()` would yield useful information for *this* module).
+- A four-round audit (PROTOCOL_SPEC text + features docs + Module-interface contract + 3 SDK source reads) confirmed that the metadata layer is fully free-form: `apcore-python` `metadata: dict[str, Any]`, `apcore-typescript` `metadata: Record<string, unknown>`, `apcore-rust` `serde_json::Value`. None of the SDKs hard-code an `x-*` allowlist; `.claude/rules/protocol-spec.md` further constrains the team from inventing new `x-*` keys outside §4.6.
+
+**Resolution**
+- Register three new `x-*` keys in the §4.6 conventions table and add a corresponding "Routing & Verification Hints" YAML example block:
+  - `x-reasoning-demand` — `low` | `medium` | `high` (Routing).
+  - `x-required-context-keys` — array of strings naming `context.data` keys the module reads (Planning). Framework-owned Context fields (`trace_id`, `caller_id`, etc.) are explicitly **not** included.
+  - `x-supports-dry-run` — boolean, module-level signal that `Executor.validate()` is meaningful (Verification).
+- **No SDK behavior change.** Framework continues to ignore unknown metadata content (§4.6 "Metadata Design Principles"); strict-mode export (§4.16) auto-strips all `x-*` keys including these.
+- **No normative MUST / MUST NOT.** Conventions only — consistent with the existing 18 `x-*` entries in §4.6.
+
+**Status**: **resolved**. See `PROTOCOL_SPEC.md` §4.6 ("Routing & Verification Hints" YAML block + table rows) and `CHANGELOG.md` `[Unreleased]` block.
+
+**Cross-refs**:
+- Stage 1 of the apcore frontier-alignment plan (`/Users/tercelyi/.claude/plans/apcore-toolkit-cli-harmonic-starlight.md`).
+- Literature: RouteLLM (ICLR 2025); xRouter (arXiv 2510.08439); Cost-Aware Model Orchestration (Smirnova, arXiv 2512.01099); Budget-Aware Tool-Use (arXiv 2511.17006); ToolMaker (ACL 2025, arXiv 2502.11705) — see `docs/spec/rfc-ephemeral-modules.md` and `docs/spec/rfc-preview-method.md` for adjacent RFCs.


### PR DESCRIPTION
## Summary

- Add three new `x-*` AI-routing keys to `PROTOCOL_SPEC.md` §4.6 conventions table
- Document via `D-57` decision log entry and `CHANGELOG.md` `[Unreleased]` block
- Pure docs change — no SDK behavior change, no `MUST` / `MUST NOT` additions

## Context

Stage 1 of the apcore frontier-research alignment audit (2025–2026 LLM-agent / tool-use research). The three new conventions:

- `x-reasoning-demand` (`low` / `medium` / `high`) — hint for upstream model routers. Supports the consumer pattern in RouteLLM (ICLR 2025), xRouter (arXiv 2510.08439), Cost-Aware Model Orchestration (Smirnova, arXiv 2512.01099), Budget-Aware Tool-Use (arXiv 2511.17006).
- `x-required-context-keys` — array of `context.data` keys the module reads (orchestrators / `apcore-mcp` bridges can pre-fetch and inject).
- `x-supports-dry-run` (boolean) — module-level signal that `Executor.validate()` (§12.2) is meaningful for this module.

`.claude/rules/protocol-spec.md` mandates: *"Do not invent x- extension fields not already listed in §4.6"* — this PR registers them in the canonical landing spot.

## Cross-SDK impact

**None.** All three SDKs treat `metadata` as freeform:

| SDK | Metadata type |
|-----|---------------|
| `apcore-python` | `dict[str, Any]` |
| `apcore-typescript` | `Record<string, unknown>` |
| `apcore-rust` | `serde_json::Value` |

None hardcodes an `x-*` allowlist. §4.16 strict-mode export auto-strips all `x-*` fields, so the new keys do not surface in strict-mode output.

## Verification (locally checked)

- `mkdocs build` → no new warnings (the 28 pre-existing warnings in `algorithms.md` / `conformance.md` / `security-considerations.md` / `type-mapping.md` / `design-context-annotations-acl.md` for `../../PROTOCOL_SPEC.md` dead links are unaffected by this PR)
- `grep -n "x-reasoning-demand\|x-required-context-keys\|x-supports-dry-run" PROTOCOL_SPEC.md` → 6 hits (3 in YAML example + 3 in conventions table)
- `git diff schemas/` → empty (no schema files touched)
- `git diff PROTOCOL_SPEC.md` → no `MUST` / `MUST NOT` additions or removals

## Files

- `PROTOCOL_SPEC.md` — §4.6 new "Routing & Verification Hints" YAML block + 3 table rows
- `CHANGELOG.md` — `[Unreleased]` block describing the addition + cross-SDK impact note
- `docs/spec/2026-05-decision-log.md` — full `D-57` entry + Resolution status update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Linked issue**: closes #56