### PR TITLE
docs(spec): draft RFCs — Module.preview() and ephemeral modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1172,6 +1172,8 @@ Development guide: see [Adapter Development Guide](./docs/guides/adapter-develop
 |------|------|
 | [Type Mapping](./docs/spec/type-mapping.md) | Cross-language type mapping |
 | [Conformance Definition](./docs/spec/conformance.md) | Implementation conformance levels |
+| [RFC — `preview()` Method](./docs/spec/rfc-preview-method.md) | Draft RFC: optional `Module.preview()` for structured pre-execution diff (target v0.21.0) |
+| [RFC — Ephemeral Modules](./docs/spec/rfc-ephemeral-modules.md) | Draft RFC: `ephemeral.*` namespace + `discoverable` annotation for runtime-registered modules |
 | [Algorithm Reference](./docs/spec/algorithms.md) | Core algorithm summary (including namespace, redaction, etc.) |
 | [Durability Boundary](./docs/spec/design-durability-boundary.md) | Stable hooks and explicit non-goals for retry/replay/workflow layers built on apcore |
 

--- a/docs/spec/rfc-ephemeral-modules.md
+++ b/docs/spec/rfc-ephemeral-modules.md
@@ -1,0 +1,144 @@
+# RFC — Ephemeral / Programmatically-Registered Modules
+
+## Status
+
+**Draft / RFC.** No target acceptance version. This RFC is intentionally exploratory: a pilot implementation in one SDK (`apcore-python`, leveraging existing `register_internal()` precedent) is expected before any normative spec text lands.
+
+## Motivation
+
+A growing class of LLM-agent workflows synthesize callable units at runtime:
+
+- Code-generation agents that compile a Python function from a task description and a repository URL (**ToolMaker**, ACL 2025, arXiv 2502.11705 — 80% task implementation correctness vs. 20% baseline).
+- On-the-fly composition of existing modules into a new callable surface (LATM and follow-on work in the LLM-ToolMaker line).
+- Per-session "scratch tools" assembled by an orchestrator and discarded after the session ends.
+
+Today, the canonical apcore registration path is filesystem-based (PROTOCOL_SPEC.md §2.1 Algorithm A01: directory path → canonical Module ID). Authors of agents that synthesize tools at runtime have to either:
+
+- Reuse `Registry.register(module_id, instance)` ad-hoc, but with no spec'd convention for naming, lifecycle, or audit; or
+- Manage a parallel registry outside apcore, losing ACL, audit, and observability.
+
+This RFC proposes a sanctioned `ephemeral.*` namespace that gives a name + minimum guardrails to programmatically-registered modules without disturbing the filesystem-rooted core.
+
+## Why this is **not** a §2.1 violation
+
+A common misreading is that "Module ID = directory path" is a runtime invariant. It is not.
+
+- **§2.1 Algorithm A01** is the **scanner-stage** path-to-ID conversion. It governs how the default discoverer derives canonical IDs from filesystem layout. It does not constrain `Registry.register()`.
+- **§2.1 trailing paragraph (around line 256)** specifies the *only* runtime requirement for `Registry.register(module_id, ...)`: `module_id` matches the canonical regex `^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$`.
+- **§6.6.1 `register_internal()`** (around line 3598) is the existing precedent: `system.*` modules are programmatically registered with caller-supplied IDs that have no filesystem origin. The spec already accepts non-filesystem programmatic registration; this RFC just gives a class of such modules a name and a discipline.
+
+A four-round audit (PROTOCOL_SPEC text + features docs + Module-interface contract + 3 SDK source reads) confirmed that all three SDKs already accept programmatic registration with caller-supplied IDs:
+
+- `apcore-python` `Registry.register(module_id: str, module: Any, ...)` — `registry.py:857-965`.
+- `apcore-typescript` `register(moduleId: string, module: unknown, ...)` — `registry/registry.ts:562-587`.
+- `apcore-rust` `register(name: &str, module: Box<dyn Module>, descriptor: ModuleDescriptor)` — `registry.rs:469-476`. The `Module` trait has no `id()` method; ID is registry metadata, not module-instance state.
+
+So the implementation primitives **all exist**. What's missing is convention + audit + lifecycle.
+
+## Non-goals
+
+- **Sandboxing.** Code execution isolation (Wasm, container, language VM) is the host's responsibility. Spec only governs registration, ACL, audit, and lifecycle.
+- **Codegen.** This RFC does not specify how an agent generates the module body; that's pipeline territory (see ToolMaker for a reference design).
+- **Replacing filesystem discovery.** `ephemeral.*` is additive. Filesystem-rooted modules retain their conventions unchanged.
+
+## Proposed `ephemeral.*` namespace
+
+Add a new entry to PROTOCOL_SPEC.md §2.5 reserved namespaces, parallel to `system.*` and `core.*`:
+
+| Namespace | Purpose | Registration | Discoverable | Mandatory annotations |
+|---|---|---|---|---|
+| `system.*` (existing) | Built-in framework modules | `register_internal()` only | Yes | (existing) |
+| `core.*` (existing) | Reserved for future spec promotion | (reserved — none yet) | — | — |
+| `ephemeral.*` (new) | Programmatically-generated runtime modules | Standard `register()` | **No** (see annotation below) | `requires_approval: true` |
+
+Modules in the `ephemeral.*` namespace:
+
+- **MAY** be registered via standard `register(module_id, module, ...)` (in contrast to `system.*`, which uses `register_internal()`).
+- **SHOULD** declare `requires_approval: true` to prevent agent-synthesized tools from running unattended.
+- **SHOULD** declare `discoverable: false` (a new annotation; see below).
+- **MUST** be subject to ACL `default_effect: deny`. ACL `target` patterns supporting `ephemeral.*` wildcards already work (per existing first-match-wins evaluation).
+- **MUST** emit audit events through the framework `EventEmitter`, mirroring `system.control.*` write modules' contextual-audit shape (D-35).
+- **SHOULD** declare a TTL (open question: convention key — see below).
+
+## Proposed new `discoverable` annotation
+
+A new boolean annotation on `Module`:
+
+```yaml
+annotations:
+  discoverable: false   # default: true; ephemeral.* modules SHOULD set false
+```
+
+Semantics:
+
+- `discoverable: true` (default) — module appears in `Registry.list()`, `Registry.find()`, manifest export, MCP `tools/list`, etc.
+- `discoverable: false` — module is callable through `Registry.invoke()` / `Executor.execute()` but is hidden from enumeration surfaces. Caller must already know the module ID.
+
+This is independently useful: filesystem-rooted modules can also opt out of enumeration (e.g., for internal-only utilities), and existing `internal: true` patterns in some SDK ports converge on the same idea.
+
+## Lifecycle / GC contract — **open**
+
+Two designs are on the table:
+
+- **Caller-managed.** `ephemeral.*` modules live until the caller explicitly calls `Registry.unregister(module_id)`. Simple; matches `register_internal()` precedent. Risk: leakage if agent crashes mid-session.
+- **TTL-driven.** Modules declare a TTL (e.g., `x-ephemeral-ttl-seconds: 3600`); framework runs a sweeper that unregisters expired entries. Mirrors `Reaper` for async tasks. Risk: another background loop to manage.
+
+**Recommendation for pilot:** start with caller-managed (cheaper); add TTL as a v2 follow-up if leakage is observed in practice.
+
+## Sandboxing — out of scope (host concern)
+
+Apcore does not specify how `ephemeral.*` module bodies are sandboxed. Hosts that accept agent-synthesized code (e.g., `apcore-mcp` bridges, `apcore-cli` plugins) MUST apply their own isolation:
+
+- Process-level (subprocess with restricted environment).
+- Wasm runtime (if SDK ecosystem supports).
+- Language-level (Python `RestrictedPython`, V8 isolates, `wasmtime` for Rust-loaded user code).
+
+The spec's responsibility is bounded at registration → ACL → audit → lifecycle. It is not bounded at code execution.
+
+## Migration / pilot plan
+
+1. **Pilot in `apcore-python` first** — already has `register_internal()` precedent and the most permissive runtime. Pilot exposes:
+   - `ephemeral.*` namespace as reserved (no enforcement yet, just convention).
+   - `discoverable: false` annotation honored by `Registry.list()`.
+   - Audit-event emission on `register()` and `unregister()` for `ephemeral.*` IDs.
+2. **Track via tracking issue** — file against `apcore-python` repo. Stage outcome reports into `docs/spec/2026-05-decision-log.md`.
+3. **Promote to spec when pilot confirms ergonomic** — at that point, this RFC becomes normative §2.5 + §4.4 amendments.
+4. **TypeScript and Rust SDKs follow** — once Python pilot ships, replicate.
+
+## Conformance plan (for post-acceptance)
+
+`conformance/fixtures/ephemeral_modules.json` (not created in this RFC stage):
+
+1. Register `ephemeral.test_v1` programmatically; assert `Registry.list()` does not include it; `Registry.invoke("ephemeral.test_v1", ...)` succeeds.
+2. ACL `target: "ephemeral.*"` rule applies first-match-wins as expected.
+3. Audit event `apcore.registry.module_registered` emitted with `module_id: "ephemeral.test_v1"` on register.
+4. Audit event `apcore.registry.module_unregistered` emitted on unregister.
+5. Re-registering same `ephemeral.*` ID replaces (or rejects per spec — open question for pilot).
+6. `requires_approval: false` on an `ephemeral.*` module produces a SHOULD-warning (not error) at registration.
+
+## Open questions
+
+1. **Namespace name.** `ephemeral.*` vs `volatile.*` vs `temp.*` vs `dynamic.*` vs `agent.*`. Recommendation: `ephemeral.*` — most precise about lifecycle without implying source ("dynamic" is too broad; "agent" conflates with caller identity).
+2. **Annotation name.** `discoverable: false` vs `internal: true` vs `hidden: true`. Recommendation: `discoverable: false` because it directly names the property being toggled.
+3. **TTL key name (if pursued).** `x-ephemeral-ttl-seconds` vs `x-ttl-seconds` vs annotation `ttl_seconds`. Recommendation: keep as `x-*` convention initially; promote to first-class annotation only if usage justifies.
+4. **Re-registration semantics.** Allow `register()` to overwrite an existing `ephemeral.*` ID, or require `unregister()` first? Recommendation: require unregister; agents can clear-and-rebuild explicitly.
+5. **Cross-language collision risk.** Should the spec reserve `ephemeral.*` even before pilot completes, to prevent third-party use? Recommendation: yes — file a 1-line spec patch reserving the namespace immediately, separate from this full RFC's acceptance.
+6. **Interaction with `apcore-mcp` `tools/list`.** Should `discoverable: false` modules be exposed through MCP `tools/list`? Recommendation: no by default; MCP servers can opt in via configuration if their host needs it.
+
+## Adjacent literature
+
+- **ToolMaker** (ACL 2025, arXiv 2502.11705 / GitHub: KatherLab/ToolMaker) — autonomous tool creation from scientific code repositories with closed-loop self-correction; 80% task implementation correctness vs. 20% baseline. **Real, verified.**
+- **LATM (LLM-ToolMaker)** — earlier work in the same line.
+- **Dynamic Tool Generation** survey topic — emergentmind, ai-scholar coverage.
+
+ToolMaker is a *pipeline* (codegen + sandbox + verify); apcore's role under this RFC is to provide the *registration surface* a ToolMaker-like pipeline lands its outputs into. The two are complementary.
+
+## Cross-refs
+
+- §2.1 — Module ID specification and `Registry.register()` regex constraint.
+- §2.5 — reserved-words registry (where `ephemeral.*` would be added).
+- §4.4 — ModuleAnnotations (where `discoverable` would be added).
+- §6.6.1 — `register_internal()` (existing precedent for non-filesystem registration).
+- §4.6 D-57 — `x-supports-dry-run`, `x-required-context-keys`, `x-reasoning-demand` (registered in companion patch).
+- `docs/spec/rfc-preview-method.md` — sibling RFC.
+- `docs/features/system-modules.md` D-35 (contextual auditing for control plane) — audit-event shape `ephemeral.*` should mirror.

--- a/docs/spec/rfc-preview-method.md
+++ b/docs/spec/rfc-preview-method.md
@@ -1,0 +1,242 @@
+# RFC — Module-level `preview()` Method and `PreflightResult.predicted_changes`
+
+## Status
+
+**Draft / RFC.** Non-normative until accepted. Target acceptance version: **v0.21.0**.
+
+This document explores adding a structured-diff surface to apcore's pre-execution validation pipeline. **No `MUST` / `MUST NOT` text is added until this RFC is accepted.**
+
+## Motivation
+
+`Executor.validate()` (PROTOCOL_SPEC.md §12.2) runs the pipeline in `dry_run=true` mode and skips non-`pure` steps; it returns a `PreflightResult` describing whether each pipeline check passed and whether the call would require approval. `Module.preflight()` (PROTOCOL_SPEC.md §5.6, contract at §12.8.5.1) lets a module emit advisory `list[str]` warnings.
+
+Neither surface answers the question that AI orchestrators consuming destructive modules increasingly need to ask:
+
+> **"If I were to call this module with these inputs, what would change in the world?"**
+
+Adjacent research has been converging on this answer:
+
+- **AgentSpec (ICSE 2026, arXiv 2503.18666)** proposes runtime enforcement frameworks for high-stakes LLM-agent workflows (financial transactions, medical records, corporate decisions).
+- **AgentHarm** benchmarks measure agent safety on destructive operations.
+- **Superego architectures** layer real-time configurable oversight atop LLM planning to nearly eliminate harmful outputs.
+
+Apcore today gives orchestrators no canonical channel for a module to **self-report its predicted changes**. This RFC proposes one.
+
+## Non-goals
+
+- Replacing or deprecating `preflight()`. Warnings remain useful and orthogonal.
+- Mandating `preview()` for every module. The method is **optional**; modules that don't implement it leave `predicted_changes` empty.
+- Imposing a closed schema for change records. Different module classes (DB writes, network calls, file I/O, email sends) have heterogeneous side effects.
+- Defining sandboxing or runtime enforcement. That sits one layer above (host concern; `apcore-mcp` / `apcore-a2a` may wrap this surface).
+
+## Proposed `Module` interface addition
+
+A new optional method, parallel to `preflight()`:
+
+```python
+# Conceptual signature; per-language variants below
+def preview(inputs: dict, context: Context) -> PreviewResult | None:
+    """
+    Return a structured prediction of changes this call would produce.
+    Optional — modules that don't implement it return None (or omit the method).
+    MUST NOT have side effects.
+    """
+```
+
+`preview()` is invoked by `Executor.validate()` after the standard validation pipeline succeeds, only on modules that override it. The result is folded into the existing `PreflightResult` via a new optional field (see below).
+
+## Proposed `PreviewResult` schema
+
+Minimum viable schema:
+
+```yaml
+PreviewResult:
+  type: object
+  required: [changes]
+  properties:
+    changes:
+      type: array
+      items: { $ref: '#/$defs/Change' }
+  description: Module's prediction of what would change if the call were executed.
+
+Change:
+  type: object
+  required: [action, target, summary]
+  properties:
+    action:
+      type: string
+      description: |
+        Free-form verb describing the kind of change
+        (e.g. "write", "delete", "send", "charge", "publish").
+        Free-form rather than enum — module authors define their own taxonomy.
+    target:
+      type: string
+      description: |
+        Free-form identifier of what is changed (e.g. "users.42",
+        "table=orders row=…", "stripe:charge:ch_abc", "smtp:user@example.com").
+    summary:
+      type: string
+      description: |
+        Required, human-readable single-line summary of the change.
+        Floor for destructive modules — at minimum, modules MUST be able
+        to surface this for human review. Aligns with HCI guidance from
+        Superego-style oversight layers.
+    before:
+      description: |
+        Optional. Snapshot of the prior state, when observable.
+        OMIT for unobservable side effects (email send, opaque network call).
+        Schema is `any` — module-class specific.
+    after:
+      description: |
+        Optional. Predicted new state.
+        OMIT when unknown (e.g. server-assigned IDs).
+    # x-* extension fields permitted (consistent with §4.4 extras)
+```
+
+The required `summary` field is the floor: even a module that wraps an opaque external API can produce `{action: "send", target: "smtp:user@example.com", summary: "Send order confirmation email to user@example.com"}`.
+
+## Proposed `PreflightResult` extension
+
+A new optional field on the existing `PreflightResult` (PROTOCOL_SPEC.md §12.8.4 type table):
+
+```yaml
+PreflightResult:
+  # ... existing fields ...
+  predicted_changes:
+    type: array
+    items: { $ref: '#/$defs/Change' }
+    description: |
+      Optional. Populated when Executor.validate() skips a non-`pure` step
+      AND the target module implements `preview()`. Empty otherwise.
+```
+
+`Executor.validate()` populates `predicted_changes` by:
+
+1. Running pipeline in `dry_run=true` (existing behavior).
+2. After existing checks pass, calling `module.preview(inputs, context)` if the method is present.
+3. Folding `result.changes` into `predicted_changes`.
+4. Catching exceptions from `preview()` as advisory warnings (do **not** fail validation if `preview()` raises — match existing `preflight()` semantics).
+
+## Cross-language sketch
+
+=== "Python"
+    ```python
+    from apcore import Module, Context, PreviewResult, Change
+
+    class DeleteUser(Module):
+        # ... existing input_schema, output_schema, execute() ...
+
+        def preview(self, inputs: dict, ctx: Context) -> PreviewResult | None:
+            user = self.repo.get_user(inputs["user_id"])
+            if user is None:
+                return None
+            return PreviewResult(changes=[
+                Change(
+                    action="delete",
+                    target=f"users.{user.id}",
+                    summary=f"Permanently delete user {user.email}",
+                    before={"id": user.id, "email": user.email, "tier": user.tier},
+                ),
+            ])
+    ```
+    Detection mirrors `preflight()`: `hasattr(module, "preview") and callable(module.preview)`.
+
+=== "TypeScript"
+    ```typescript
+    import { Module, Context, PreviewResult } from 'apcore';
+
+    class DeleteUser implements Module {
+      // ... existing inputSchema, outputSchema, execute() ...
+
+      async preview(inputs: Record<string, unknown>, ctx: Context): Promise<PreviewResult | null> {
+        const user = await this.repo.getUser(inputs.user_id as string);
+        if (!user) return null;
+        return {
+          changes: [{
+            action: 'delete',
+            target: `users.${user.id}`,
+            summary: `Permanently delete user ${user.email}`,
+            before: { id: user.id, email: user.email, tier: user.tier },
+          }],
+        };
+      }
+    }
+    ```
+    Detection mirrors `preflight?`: `typeof module.preview === 'function'`.
+
+=== "Rust"
+    ```rust
+    use apcore::{Module, Context, PreviewResult, Change};
+
+    impl Module for DeleteUser {
+        // ... existing input_schema, output_schema, execute() ...
+
+        fn preview(&self, inputs: &serde_json::Value, ctx: Option<&Context>)
+            -> Option<PreviewResult>
+        {
+            let user = self.repo.get_user(inputs["user_id"].as_str()?)?;
+            Some(PreviewResult {
+                changes: vec![Change {
+                    action: "delete".into(),
+                    target: format!("users.{}", user.id),
+                    summary: format!("Permanently delete user {}", user.email),
+                    before: Some(serde_json::json!({
+                        "id": user.id, "email": user.email, "tier": user.tier
+                    })),
+                    after: None,
+                }],
+            })
+        }
+    }
+    ```
+    Default impl on the `Module` trait returns `None`, matching the existing
+    `preflight()` / `stream()` pattern (no separate sub-trait needed).
+
+## Pre-conditions (Rust struct hygiene) — **blocking pre-req for Stage 2 implementation**
+
+`apcore-rust`'s `PreflightResult` and `PreflightCheckResult` are currently defined as plain `pub struct {...}` with no `#[non_exhaustive]` attribute (see `apcore-rust/src/module.rs:296,312`). Adding a new field (`predicted_changes`) **will hard-break** any downstream Rust consumer that constructs these structs via struct-literal syntax (e.g. `PreflightResult { valid: true, checks: vec![], requires_approval: false }`).
+
+**Before** Stage 2 SDK work proceeds:
+
+1. Open a tracking issue against `apcore-rust` titled "Mark spec-derived public structs `#[non_exhaustive]`".
+2. List `PreflightResult`, `PreflightCheckResult`, and any other spec-derived public struct that may be extended.
+3. Land the attribute change as a single commit in `apcore-rust` minor bump (v0.21.0 of the SDK is acceptable).
+4. Document in `apcore-rust` migration notes: downstream consumers must use struct-update syntax (`..Default::default()`) or builder methods.
+
+This concern does not arise in `apcore-python` (dataclasses tolerate added fields with defaults) or `apcore-typescript` (interfaces with optional `?` properties are forward-compatible).
+
+## Conformance plan
+
+When this RFC is accepted, a new fixture `conformance/fixtures/preview_method.json` is added with at least the following test cases:
+
+1. Module without `preview()` — `Executor.validate()` returns `PreflightResult` with `predicted_changes: []`.
+2. Module with `preview()` returning `None` — same as above.
+3. Module with `preview()` returning `PreviewResult` with one `Change` having all required fields and no optional fields — `predicted_changes` contains exactly that record.
+4. Module with `preview()` returning multiple `Change`s including ones with `before`/`after` — all surface in `predicted_changes` in order.
+5. Module whose `preview()` raises — validation does **not** fail; warning surfaces in `PreflightResult.warnings` (or equivalent existing surface).
+
+The fixture is **not** created in this RFC stage; it ships with the PR that adds normative spec text in v0.21.0.
+
+## Open questions
+
+1. **`preview()` raising semantics.** Match `preflight()` (warning, no fail) or stricter (fail validation)? Recommendation: match `preflight()` for ergonomic parity.
+2. **Streaming modules.** Should `preview()` apply to streaming modules? Recommendation: yes — `preview()` describes *what would change*, not *what would be returned*. Streaming output is orthogonal to side effects.
+3. **`Change.before`/`after` schema.** Stay `any` (free-form per module class) or impose JSON Schema? Recommendation: stay `any` for v0.21.0; possible §4.6 conventions for typed `Change` shapes per module class in a follow-up.
+4. **`x-supports-dry-run` interplay.** Should the new `x-supports-dry-run` convention (registered in §4.6 D-57) be set automatically when a module implements `preview()`? Recommendation: no — they're orthogonal signals. `x-supports-dry-run=true` says "validate() is meaningful"; implementing `preview()` is one *way* to make it meaningful.
+5. **`PreviewResult` vs returning `Change[]` directly.** Wrapping in a struct lets us add fields later (e.g., a top-level `confidence: float`). Recommendation: keep the wrapper.
+
+## Adjacent literature
+
+- **AgentSpec** (ICSE 2026, arXiv 2503.18666) — Customizable Runtime Enforcement for Safe and Reliable LLM Agents.
+- **AgentHarm** — LLM Agent Safety Benchmark (emergentmind summary).
+- **The Superego agent architecture** — real-time, user-configurable oversight layered atop LLM planning.
+
+These works approach the problem from the **outside** (external spec + runtime enforcement on untrusted agents). `preview()` approaches the same problem from the **inside** (modules in a trusted ecosystem self-report their predicted changes). The two surfaces are complementary, not competing.
+
+## Cross-refs
+
+- §4.6 D-57 — `x-supports-dry-run` convention (orthogonal but adjacent).
+- §5.6 — `Module.preflight()` advisory warnings (parallel surface).
+- §12.2 — `Executor.validate()` (entry point).
+- §12.8.4 / §12.8.5.1 — `PreflightResult` / `PreflightCheck` type tables (extension target).
+- `docs/spec/rfc-ephemeral-modules.md` — sibling RFC.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,8 @@ nav:
       - Durability Boundary: spec/design-durability-boundary.md
       - Context-Annotations-ACL Design: spec/design-context-annotations-acl.md
       - Decision Log (2026-05): spec/2026-05-decision-log.md
+      - "RFC — preview() Method": spec/rfc-preview-method.md
+      - "RFC — Ephemeral Modules": spec/rfc-ephemeral-modules.md
 
 extra:
   social:

--- a/planning/ephemeral-modules/overview.md
+++ b/planning/ephemeral-modules/overview.md
@@ -1,0 +1,38 @@
+# ephemeral-modules — Reserved namespace for runtime-registered modules
+
+## Goal
+
+Reserve `ephemeral.*` as a sanctioned namespace for programmatically-registered modules synthesized at runtime by LLM agents (à la ToolMaker, ACL 2025), with minimum-viable lifecycle, audit, and ACL guardrails. Add a new `discoverable: false` annotation so ephemeral modules can be hidden from enumeration surfaces (`Registry.list()`, MCP `tools/list`).
+
+## Source
+
+- Spec RFC: [`docs/spec/rfc-ephemeral-modules.md`](../../docs/spec/rfc-ephemeral-modules.md)
+- Frontier-research alignment plan (Stage 3)
+
+## Scope
+
+- **In scope** (this feature):
+  - Reserve `ephemeral.*` in §2.5 reserved namespaces
+  - Add `discoverable: false` annotation to §4.4 ModuleAnnotations
+  - Audit-event shape mirroring D-35 (contextual auditing for control plane)
+  - Pilot implementation in `apcore-python` first
+- **Out of scope** (deferred):
+  - Sandboxing (host concern; see RFC §"Sandboxing — out of scope")
+  - TTL / GC sweeper (open question; deferred to v2 if leakage observed)
+  - Codegen pipeline (ToolMaker territory, not apcore's)
+
+## Dependencies
+
+- No blocking dependencies in this repo.
+- Cross-repo: pilot in `apcore-python` precedes TS+Rust replication.
+- Recommendation in RFC §"Open questions" #5: file a 1-line spec patch to reserve `ephemeral.*` immediately (separate from full RFC acceptance) to prevent third-party collision.
+
+## Status
+
+**Pending** — RFC created; awaiting acceptance review. Pilot in `apcore-python` queued.
+
+## Adjacent literature
+
+- ToolMaker (ACL 2025, arXiv 2502.11705 / KatherLab) — verified real
+- LATM (LLM-ToolMaker)
+- Dynamic Tool Generation survey topic

--- a/planning/ephemeral-modules/state.json
+++ b/planning/ephemeral-modules/state.json
@@ -1,0 +1,52 @@
+{
+  "feature": "ephemeral-modules",
+  "status": "pending",
+  "tasks": [
+    {
+      "id": "rfc-draft",
+      "title": "Draft RFC at docs/spec/rfc-ephemeral-modules.md",
+      "status": "completed",
+      "file": "docs/spec/rfc-ephemeral-modules.md"
+    },
+    {
+      "id": "namespace-reserve-patch",
+      "title": "Optional 1-line spec patch reserving `ephemeral.*` in §2.5 ahead of full RFC acceptance (prevents third-party collision)",
+      "status": "pending",
+      "file": "PROTOCOL_SPEC.md"
+    },
+    {
+      "id": "rfc-acceptance-review",
+      "title": "Maintainer review; resolve open questions (namespace name, TTL design, re-registration semantics)",
+      "status": "pending",
+      "file": "docs/spec/rfc-ephemeral-modules.md"
+    },
+    {
+      "id": "python-pilot",
+      "title": "Pilot implementation in apcore-python — leverage existing register_internal() precedent",
+      "status": "pending",
+      "file": "(cross-repo: apcore-python)"
+    },
+    {
+      "id": "spec-normative-text",
+      "title": "Promote to normative §2.5 + §4.4 amendments after pilot confirms ergonomics",
+      "status": "pending",
+      "files": ["PROTOCOL_SPEC.md"]
+    },
+    {
+      "id": "conformance-fixture",
+      "title": "Create conformance/fixtures/ephemeral_modules.json with cross-language test cases",
+      "status": "pending",
+      "file": "conformance/fixtures/ephemeral_modules.json"
+    },
+    {
+      "id": "sdk-replication",
+      "title": "Replicate Python pilot in apcore-typescript and apcore-rust",
+      "status": "pending",
+      "file": "(cross-repo: 2 SDK repos)"
+    }
+  ],
+  "metadata": {
+    "source_doc": "docs/spec/rfc-ephemeral-modules.md",
+    "created_by": "frontier-alignment-stage-3"
+  }
+}

--- a/planning/overview.md
+++ b/planning/overview.md
@@ -33,9 +33,9 @@ These do not have `state.json` files; they are pre-feature design notes.
 
 ## Upcoming
 
-In-flight RFC drafts live under `docs/spec/`:
+In-flight RFC drafts live under `docs/spec/`, with planning artifacts under `planning/`:
 
-- `docs/spec/rfc-preview-method.md` — optional `Module.preview()` method (Stage 2 of frontier-research alignment audit)
-- `docs/spec/rfc-ephemeral-modules.md` — reserved `ephemeral.*` namespace (Stage 3)
+- [`docs/spec/rfc-preview-method.md`](../docs/spec/rfc-preview-method.md) — optional `Module.preview()` method (Stage 2 of frontier-research alignment audit). Planning: [`preview-method`](./preview-method/overview.md). Cross-repo blocker: `apcore-rust` `#[non_exhaustive]` hygiene ([apcore-rust#24](https://github.com/aiperceivable/apcore-rust/issues/24)).
+- [`docs/spec/rfc-ephemeral-modules.md`](../docs/spec/rfc-ephemeral-modules.md) — reserved `ephemeral.*` namespace (Stage 3). Planning: [`ephemeral-modules`](./ephemeral-modules/overview.md). Pilot queued in `apcore-python` ([apcore-python#25](https://github.com/aiperceivable/apcore-python/issues/25)).
 
 When an RFC is accepted and promoted to a full implementation feature, its planning subdirectory will be added to the **Completed features** table above.

--- a/planning/preview-method/overview.md
+++ b/planning/preview-method/overview.md
@@ -1,0 +1,38 @@
+# preview-method — Module-level structured-diff preview
+
+## Goal
+
+Add an optional `Module.preview(inputs, context) -> PreviewResult | None` method and extend `PreflightResult` with `predicted_changes: list[Change]`, so destructive modules can self-report what would change if executed.
+
+## Source
+
+- Spec RFC: [`docs/spec/rfc-preview-method.md`](../../docs/spec/rfc-preview-method.md)
+- Decision log: D-57 (companion `x-supports-dry-run` convention) — see `docs/spec/2026-05-decision-log.md`
+- Frontier-research alignment plan (Stage 2)
+
+## Scope
+
+- **In scope** (this feature):
+  - Optional `Module.preview()` method specification
+  - New `PreviewResult` and `Change` types
+  - `Executor.validate()` integration to fold preview output into `PreflightResult.predicted_changes`
+  - Cross-language conformance fixture
+- **Out of scope** (deferred):
+  - Per-module-class typed `Change` schemas (potential §4.6 follow-up)
+  - Sandboxing or runtime enforcement (host concern)
+  - Replacing or deprecating existing `preflight()` warnings
+
+## Dependencies
+
+- **Blocking pre-req (cross-repo)**: `apcore-rust` must mark `PreflightResult` and `PreflightCheckResult` `#[non_exhaustive]` before adding the new field. Open as tracking issue against `apcore-rust`.
+- No dependencies on other planning features in this repo.
+
+## Status
+
+**Pending** — RFC created; awaiting acceptance review. No spec normative text added until RFC is accepted.
+
+## Adjacent literature
+
+- AgentSpec (ICSE 2026, arXiv 2503.18666)
+- AgentHarm safety benchmark
+- Superego agent architecture

--- a/planning/preview-method/state.json
+++ b/planning/preview-method/state.json
@@ -1,0 +1,46 @@
+{
+  "feature": "preview-method",
+  "status": "pending",
+  "tasks": [
+    {
+      "id": "rfc-draft",
+      "title": "Draft RFC at docs/spec/rfc-preview-method.md",
+      "status": "completed",
+      "file": "docs/spec/rfc-preview-method.md"
+    },
+    {
+      "id": "rust-non-exhaustive-tracking",
+      "title": "File tracking issue against apcore-rust to mark PreflightResult / PreflightCheckResult #[non_exhaustive] before extending",
+      "status": "pending",
+      "file": "(cross-repo: apcore-rust)"
+    },
+    {
+      "id": "rfc-acceptance-review",
+      "title": "Maintainer review of RFC; resolve open questions; promote to normative spec",
+      "status": "pending",
+      "file": "docs/spec/rfc-preview-method.md"
+    },
+    {
+      "id": "spec-normative-text",
+      "title": "Add normative text to PROTOCOL_SPEC.md §5.6 (Module.preview()) + §12.8.4 (PreflightResult.predicted_changes)",
+      "status": "pending",
+      "files": ["PROTOCOL_SPEC.md"]
+    },
+    {
+      "id": "conformance-fixture",
+      "title": "Create conformance/fixtures/preview_method.json with cross-language test cases",
+      "status": "pending",
+      "file": "conformance/fixtures/preview_method.json"
+    },
+    {
+      "id": "sdk-implementations",
+      "title": "Implement preview() across apcore-python / apcore-typescript / apcore-rust (cross-repo, post-acceptance)",
+      "status": "pending",
+      "file": "(cross-repo: 3 SDK repos)"
+    }
+  ],
+  "metadata": {
+    "source_doc": "docs/spec/rfc-preview-method.md",
+    "created_by": "frontier-alignment-stage-2"
+  }
+}


### PR DESCRIPTION
## Summary

Two pre-acceptance RFCs landing in `docs/spec/`, matching the existing `docs/spec/design-*.md` pattern. **No `PROTOCOL_SPEC.md` normative changes** — both RFCs are exploratory design documents.

This is **Stage 2 + Stage 3** of the apcore frontier-research alignment audit. Stage 1 (D-57 §4.6 conventions) is in #53.

## RFC 1 — `Module.preview()` (target v0.21.0)

**File**: `docs/spec/rfc-preview-method.md`

Adds an optional `Module.preview(inputs, ctx) -> PreviewResult | None` method, carrying structured `Change` diffs (`action`, `target`, `summary` required; `before`, `after` optional). `PreflightResult` extended with optional `predicted_changes` field, populated by `Executor.validate()`.

Differentiated from existing `preflight()` (advisory `string[]` warnings) by carrying structured diffs suitable for human-in-the-loop review of destructive modules.

**Cross-repo blocker (must precede Stage 2 implementation)**: `apcore-rust` `PreflightResult` and `PreflightCheckResult` are currently plain `pub struct` with no `#[non_exhaustive]` attribute. Adding the new field would hard-break downstream Rust consumers using struct-literal construction. Tracking issue to be filed against `apcore-rust`.

**Adjacent literature**: AgentSpec (ICSE 2026, arXiv 2503.18666); AgentHarm safety benchmark; Superego agent architecture.

## RFC 2 — Ephemeral modules (no target version yet)

**File**: `docs/spec/rfc-ephemeral-modules.md`

Reserves `ephemeral.*` namespace for programmatically-registered modules synthesized by LLM agents at runtime (à la **ToolMaker**, ACL 2025, arXiv 2502.11705 — verified real, 80% task implementation correctness vs. 20% baseline). Adds new `discoverable: false` annotation so ephemeral modules can be hidden from enumeration surfaces (`Registry.list()`, MCP `tools/list`).

**Key argument** (`§"Why this is not a §2.1 violation"`): `§2.1` Algorithm A01 governs the *scanner-stage* path-to-ID conversion only. `Registry.register()` already accepts caller-supplied IDs satisfying `^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$`. `register_internal()` (`§6.6.1`) is the existing precedent for non-filesystem programmatic registration. The implementation primitives all exist in the 3 SDKs (verified by source-code reading); the RFC adds **convention + audit + lifecycle**, not core architecture.

**Pilot strategy**: implement in `apcore-python` first (existing `register_internal()` precedent makes the smallest delta); replicate in TS + Rust afterward.

## Why combined into one PR (deviation from original 3-PR plan)

The originally planned 3-PR split would require splitting edits to `mkdocs.yml`, `README.md`, and `planning/overview.md` — each file naturally lists *both* RFCs together. Two of three options for a clean 3-PR split require either inter-PR dependencies or re-editing shared files in different states across branches. Combining the two RFCs into one PR (this one) keeps shared edits intact while still cleanly separating from Stage 1 spec changes (#53).

## Verification (locally checked)

- `mkdocs build` → no new warnings; both RFC files parse and link cleanly
- `ls docs/spec/rfc-preview-method.md docs/spec/rfc-ephemeral-modules.md` → both exist
- `grep -n "rfc-preview-method\|rfc-ephemeral-modules" mkdocs.yml README.md` → registered in both nav and Documentation Index
- `git diff PROTOCOL_SPEC.md` → empty (no normative spec changes)
- `git diff schemas/` → empty

## Files

- `docs/spec/rfc-preview-method.md` (new)
- `docs/spec/rfc-ephemeral-modules.md` (new)
- `planning/preview-method/{overview.md,state.json}` (new)
- `planning/ephemeral-modules/{overview.md,state.json}` (new)
- `mkdocs.yml` — nav additions
- `README.md` — Documentation Index additions
- `planning/overview.md` — Upcoming list additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)