### PR TITLE
docs(planning): refresh planning/overview.md to reflect actual state

### DIFF
--- a/planning/overview.md
+++ b/planning/overview.md
@@ -1,17 +1,41 @@
 # apcore Implementation Plans — Project Overview
 
-## Features
+This directory tracks internal implementation plans for spec-derived features. Each subdirectory contains an `overview.md` (goals + scope) and a `state.json` (machine-readable progress). User-facing documentation lives in `docs/`, never here (per `.claude/rules/planning.md`).
 
-| Feature | Tasks | Status | Source |
-|---------|-------|--------|--------|
-| [context-redesign](./context-redesign/overview.md) | 7 | pending | [docs/features/context-redesign.md](../docs/features/context-redesign.md) |
+## Completed features
 
-## Recommended Implementation Order
+| Feature | Tasks | Source spec |
+|---------|-------|-------------|
+| [acl-conditions-redesign](./acl-conditions-redesign/overview.md) | 7 | `docs/features/acl-system.md` |
+| [annotations-redesign](./annotations-redesign/overview.md) | 5 | `docs/features/schema-system.md` |
+| [async-task-evolution](./async-task-evolution/overview.md) | 3/3 | [`docs/features/async-tasks.md`](../docs/features/async-tasks.md) |
+| [context-redesign](./context-redesign/overview.md) | 7/7 | [`docs/api/context-object.md`](../docs/api/context-object.md) |
+| [event-management-hardening](./event-management-hardening/overview.md) | 3/3 | [`docs/features/event-system.md`](../docs/features/event-system.md) |
+| [execution-pipeline](./execution-pipeline/overview.md) | 7 | `docs/features/core-executor.md` |
+| [middleware-hardening](./middleware-hardening/overview.md) | 3/3 | [`docs/features/middleware-system.md`](../docs/features/middleware-system.md) |
+| [multi-module-discovery](./multi-module-discovery/overview.md) | 4/4 | [`docs/features/multi-module-discovery.md`](../docs/features/multi-module-discovery.md) |
+| [observability-hardening](./observability-hardening/overview.md) | 3/3 | [`docs/features/observability.md`](../docs/features/observability.md) |
+| [pipeline-hardening](./pipeline-hardening/overview.md) | 4/4 | [`docs/features/core-executor.md`](../docs/features/core-executor.md) |
+| [schema-hardening](./schema-hardening/overview.md) | 6/6 | [`docs/features/schema-system.md`](../docs/features/schema-system.md) |
+| [system-modules-hardening](./system-modules-hardening/overview.md) | 3/3 | [`docs/features/system-modules.md`](../docs/features/system-modules.md) |
+| [trace-context-unification](./trace-context-unification/overview.md) | 7/7 | `docs/features/observability.md` (TraceContext §) |
 
-1. **context-redesign** — foundational; ACL and Pipeline depend on Context changes
+Tasks listed without a `done/total` ratio (e.g. `7`) lack a per-task array in their `state.json`; the feature is marked `status: completed` but task-level completion records weren't captured at the time.
 
-## Upcoming (not yet planned)
+## Spec patch drafts
 
-- annotations-redesign — depends on: none (parallel with context)
-- acl-conditions-redesign — depends on: context-redesign
-- execution-pipeline — depends on: context-redesign, acl-conditions-redesign
+Lightweight `PROTOCOL_SPEC.md` patch drafts that haven't been picked up as full features yet:
+
+- [acl-compound-operators-spec-patch](./acl-compound-operators-spec-patch/overview.md) — proposed ACL compound-operators extension
+- [validate-step-count-spec-patch](./validate-step-count-spec-patch/overview.md) — proposed `validate()` step-count clarification
+
+These do not have `state.json` files; they are pre-feature design notes.
+
+## Upcoming
+
+In-flight RFC drafts live under `docs/spec/`:
+
+- `docs/spec/rfc-preview-method.md` — optional `Module.preview()` method (Stage 2 of frontier-research alignment audit)
+- `docs/spec/rfc-ephemeral-modules.md` — reserved `ephemeral.*` namespace (Stage 3)
+
+When an RFC is accepted and promoted to a full implementation feature, its planning subdirectory will be added to the **Completed features** table above.


### PR DESCRIPTION
## Summary

`planning/overview.md` had drifted significantly from reality. It listed only `context-redesign` as a feature (status: `pending`) plus three "Upcoming" items, while `planning/` actually contains **13 completed features + 2 spec-patch drafts** (15 subdirectories total).

This PR refreshes the file based on each feature's `state.json`.

## What changed

**Before** — single feature listed, all four entries describing pending/upcoming work that has long since shipped:

```
| Feature | Tasks | Status | Source |
|---------|-------|--------|--------|
| [context-redesign](./context-redesign/overview.md) | 7 | pending | … |

## Upcoming (not yet planned)
- annotations-redesign — depends on: none (parallel with context)
- acl-conditions-redesign — depends on: context-redesign
- execution-pipeline — depends on: context-redesign, acl-conditions-redesign
```

**After** — three sections:

1. **Completed features** (13 entries) — all features whose `state.json` reports `status: completed`, with task counts and source-spec links verified to exist on disk
2. **Spec patch drafts** (2 entries) — `acl-compound-operators-spec-patch` and `validate-step-count-spec-patch`, which have only `overview.md` (no `state.json`) and represent pre-feature design notes
3. **Upcoming** — points to in-flight RFCs in `docs/spec/` (`rfc-preview-method.md`, `rfc-ephemeral-modules.md`)

## Verified

- Each feature's `state.json` was inspected; status read from `d['status']`, task counts from `len(d['tasks'])` and the per-task `status` field
- Each source-spec link in the table has been verified to exist via `test -f`
- No external-facing change; `planning/` is internal-only per `.claude/rules/planning.md`
- No SDK changes, no normative spec changes

## Coordination

#54 (frontier-research RFCs) also touches `planning/overview.md` — adding `preview-method` and `ephemeral-modules` to the old "Upcoming (not yet planned)" list. Whichever PR lands first, the other will need a trivial rebase. Recommendation: merge this one first (smaller scope, internal-only doc), then rebase #54 to add its two entries to the new "Upcoming" section directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)