### PR TITLE
docs(spec): apply doc-only follow-through fixes (D-01, D-07, D-16, D-18, D-26)

### DIFF
--- a/PROTOCOL_SPEC.md
+++ b/PROTOCOL_SPEC.md
@@ -2203,9 +2203,9 @@ context_schema:
           description: "Unique identifier"
         type:
           type: string
-          enum: [user, service, agent, api_key, system]
+          examples: [user, service, agent, api_key, system, ai]
           default: "user"
-          description: "Identity type"
+          description: "Identity type (free-form string; well-known values shown in examples)"
         roles:
           type: array
           items:

--- a/docs/features/call-chain-guard.md
+++ b/docs/features/call-chain-guard.md
@@ -207,7 +207,7 @@ Modules that perform nested calls (calling other modules within their execution)
 ### Errors
 - `CallDepthExceededError(code=CALL_DEPTH_EXCEEDED)` — call chain depth exceeds `max_depth`
 - `CircularCallError(code=CIRCULAR_CALL)` — `module_id` already appears in the current call chain (cycle detected)
-- `FrequencyExceededError(code=FREQUENCY_EXCEEDED)` — `module_id` has been invoked more than `max_repeat` times in this chain
+- `CallFrequencyExceededError(code=CALL_FREQUENCY_EXCEEDED)` — `module_id` has been invoked more than `max_repeat` times in this chain
 
 ### Returns
 - On success (guard passes): void/None/() — no return value; raises on violation

--- a/docs/features/identity-system.md
+++ b/docs/features/identity-system.md
@@ -81,7 +81,17 @@ The Identity System provides a structured representation of the caller's identit
 | `anonymous` | No authenticated identity | Public endpoints, unauthenticated callers |
 
 !!! note
-    The `type` field is free-form — these are conventions, not exhaustive. Applications may define custom types.
+    The `type` field is a free-form string. The values above are the well-known conventions surfaced in the JSON Schema `examples` (PROTOCOL_SPEC.md §5.7). Applications **MAY** define custom types — implementations do not validate the value against the conventions list.
+
+### Equality and hashability
+
+`Identity` is a value type. Equality is **structural** — two identities are equal iff `id`, `type`, `roles`, and `attrs` are equal as deep value comparisons. Hashability is **implementation-defined per language**:
+
+- **Rust**: `Identity` derives `Hash` and `Eq`; safe to use as a `HashMap` key.
+- **Python**: `Identity` is a frozen dataclass, but the `attrs: dict` field makes it not hashable by default; cross-language code SHOULD NOT rely on `hash(identity)` portability.
+- **TypeScript**: object literal; equality and hashing are caller's responsibility (use a stable serialization or a structural-equality helper).
+
+Resolved per `docs/spec/2026-05-decision-log.md` D-26.
 
 ### Usage with Context
 

--- a/docs/features/streaming.md
+++ b/docs/features/streaming.md
@@ -99,15 +99,17 @@ After all chunks have been emitted, the accumulated output is passed through Out
         fn input_schema(&self) -> Value { json!({"type": "object", "properties": {"prompt": {"type": "string"}}}) }
         fn output_schema(&self) -> Value { json!({"type": "object", "properties": {"content": {"type": "string"}}}) }
 
-        async fn stream(&self, inputs: Value, ctx: &Context<Value>) -> Result<Vec<Value>, ModuleError> {
-            let prompt = inputs["prompt"].as_str().unwrap();
-            let mut chunks = Vec::new();
-            // Produce chunks incrementally
-            for token in llm_client_stream(prompt).await? {
-                chunks.push(json!({"content": token, "done": false}));
-            }
-            chunks.push(json!({"content": "", "done": true}));
-            Ok(chunks)
+        // Module trait returns Option<ChunkStream> = Option<Pin<Box<dyn Stream<Item=Result<Value, ModuleError>> + Send>>>.
+        // None signals "no streaming support — fall back to execute() wrapped as a single chunk" (per spec).
+        fn stream(&self, inputs: Value, _ctx: &Context<Value>) -> Option<ChunkStream> {
+            let prompt = inputs["prompt"].as_str()?.to_string();
+            Some(Box::pin(async_stream::stream! {
+                // Produce chunks incrementally
+                for token in llm_client_stream(&prompt).await? {
+                    yield Ok(json!({"content": token, "done": false}));
+                }
+                yield Ok(json!({"content": "", "done": true}));
+            }))
         }
     }
     ```

--- a/docs/spec/2026-05-decision-log.md
+++ b/docs/spec/2026-05-decision-log.md
@@ -788,21 +788,38 @@ the same fixture file.
 
 ## Resolution status
 
-- **Resolved** (no further action): D-02, D-05, D-23, D-29, D-30, D-31, D-32, D-34, D-35, D-36, D-37, D-38, D-41, D-42, D-43, D-44, D-45, D-46, D-54, D-55, D-56, D-57
-- **Doc-only fixes** (1-line each): D-01, D-07, D-09, D-16, D-17, D-18, D-26
-- **Code fix needed in 1 SDK**: D-04 (TS), D-08 (Python), D-10 (Python), D-11 (Python), D-12 (Python), D-13 (Python), D-14 (Rust), D-19 (Rust), D-25 (TS+Rust), D-27 (Rust), D-28 (Rust)
-- **Multi-SDK code fix**: D-03 (all 3), D-15 (Python+TS), D-24 (TS+Rust)
-- **Epic / RFC needed**: D-21, D-22 (extension Arc migration)
+> **Authoritative current state** (updated 2026-05-05 after iter-9 doc-only follow-through round). Per-round narratives are preserved below in chronological addenda.
+
+- **Resolved** (50 items, no further action):
+  - D-01, D-02, D-05, D-07, D-08, D-09, D-10, D-11, D-12, D-13, D-14, D-15, D-16, D-17, D-18, D-19, D-23, D-25, D-26, D-27, D-28, D-29, D-30, D-31, D-32, D-33, D-34, D-35, D-36, D-37, D-38, D-39, D-40, D-41, D-42, D-43, D-44, D-45, D-46, D-47, D-48, D-49, D-50, D-51, D-52, D-53, D-54, D-55, D-56, D-57
+  - Notes on follow-through chains:
+    - **D-08** closed via **D-49** (TS + Rust renamed to canonical `compute_delay_ms`).
+    - **D-11** closed via **D-42** (Python `start_reaper` aliases + ms units).
+    - **D-32** closed via **D-56** (TS `_filterIdConflicts` extracted).
+  - **Doc-only follow-throughs landed in iter-9 (2026-05-05)**: D-01, D-07, D-09, D-16, D-17, D-18, D-26 — see addendum below.
+
+- **Open — multi-SDK code fix** (2 items, target v0.21.0):
+  - **D-03** — `ApprovalRequest` to add `caller_id` and `action` fields in all 3 SDKs.
+  - **D-24** — `update_config` constraints registry + rollback in TS + Rust (Python already aligned).
+
+- **Open — single-SDK code fix** (2 items, deferred):
+  - **D-04** — TS snake_case wire-format rename. Deferred per the entry's notes; needs a dedicated codemod PR (jscodeshift / sed) covering ~50 error subclasses + AuditEntry + ~30 test files. Estimated 1–2 hours focused work.
+  - **D-20** — Rust `RetryConfig::compute_delay_ms` doc-comment note about `u64` truncation. Local change in apcore-rust source only; does not require a spec edit.
+
+- **Open — minor spec cleanup** (1 item):
+  - **D-06** — Drop the unimplemented global `extensions.multi_class_discovery` config key from PROTOCOL_SPEC + `docs/features/multi-module-discovery.md`; TS drops the `multiClassEnabled` arg. Per-class decorator (Python's design) becomes the only opt-in path.
+
+- **Open — Epic / RFC** (2 items paired):
+  - **D-21** + **D-22** — ExtensionManager `Arc` migration. Multi-API breaking change cascading through Executor / Registry. Track as RFC + epic; target v0.22.0.
 
 ## Recommended sequence
 
-1. Apply doc-only fixes as a single PR in `apcore` (D-01, D-07, D-09, D-16, D-17, D-18, D-26, D-30, D-31). Low risk.
-2. Apply single-SDK code fixes per repo as separate PRs:
-   - TS D-04 (snake_case wire alignment) — needs codemod tooling, see action note
-   - Python D-10..D-13 (TaskStore + start_reaper alignment)
-   - Rust D-14, D-19, D-27, D-28 (RetryConfig default, chunk shape, UsageCollector parity, ContextLogger schema)
-3. Multi-SDK fixes (D-03 ApprovalRequest fields, D-15 discover_multi_class method, D-24 update_config rollback) batched into a v0.21.0 release.
-4. Epic D-21/D-22 (Extension Arc migration) — RFC scheduled for 2026-05-18 (routine `trig_01DCE8sCcBxm9qRxZiMvUgQo`), target v0.22.0.
+1. ✅ ~~Apply doc-only fixes as a single PR~~ — **completed in iter-9** (D-01, D-07, D-09, D-16, D-17, D-18, D-26).
+2. **D-06** spec cleanup — small follow-up PR; can ship with the next doc-cleanup round.
+3. **D-03** + **D-24** — batched into v0.21.0 multi-SDK release.
+4. **D-04** — schedule a dedicated TS codemod PR session (1–2 hrs focused).
+5. **D-20** — apcore-rust local doc comment (out of scope for this repo).
+6. **D-21** / **D-22** — RFC + epic, target v0.22.0.
 
 ---
 
@@ -1034,3 +1051,24 @@ TypeScript SDK adds `OverridesStore` interface, `FileOverridesStore` (YAML-backe
 **Cross-refs**:
 - Stage 1 of the apcore frontier-alignment plan (`/Users/tercelyi/.claude/plans/apcore-toolkit-cli-harmonic-starlight.md`).
 - Literature: RouteLLM (ICLR 2025); xRouter (arXiv 2510.08439); Cost-Aware Model Orchestration (Smirnova, arXiv 2512.01099); Budget-Aware Tool-Use (arXiv 2511.17006); ToolMaker (ACL 2025, arXiv 2502.11705) — see `docs/spec/rfc-ephemeral-modules.md` and `docs/spec/rfc-preview-method.md` for adjacent RFCs.
+
+---
+
+### Resolution status — iter-9 addendum (doc-only follow-through, 2026-05-05)
+
+The original 2026-05-02 Resolution status block listed seven entries as "Doc-only fixes" (D-01, D-07, D-09, D-16, D-17, D-18, D-26) but five of them were never executed. A re-audit in iter-9 found:
+
+- **D-09** and **D-17** had been silently closed in earlier rounds (`start()`/`stop()` already removed from PROTOCOL_SPEC §12; `caller_id_for_unknown` configurability text already removed from `acl-system.md`) but the Resolution status block was not updated to reflect this.
+- **D-01, D-07, D-16, D-18, D-26** had not been touched since the decision log was written 2 weeks earlier.
+
+Status updates landed 2026-05-05:
+
+- **D-01** — resolved. `PROTOCOL_SPEC.md` §5.7 changed `enum: [user, service, agent, api_key, system]` to `examples: [user, service, agent, api_key, system, ai]`; description clarifies the field is free-form. `docs/features/identity-system.md` admonition rewritten to reference the examples list rather than asserting "free-form" without context.
+- **D-07** — resolved. `docs/features/call-chain-guard.md:210` corrected from `FrequencyExceededError(code=FREQUENCY_EXCEEDED)` to `CallFrequencyExceededError(code=CALL_FREQUENCY_EXCEEDED)`, matching the implementation + Error Types table at line 100 of the same file.
+- **D-09** — resolved (verified). `start()` / `stop()` lifecycle mentions are absent from PROTOCOL_SPEC.md; the iter-9 audit confirmed the earlier removal.
+- **D-16** — resolved. `docs/features/streaming.md` Rust producer example rewritten to use the actual trait signature `fn stream(&self, ...) -> Option<ChunkStream>`, returning a pinned `async_stream::stream!` block that yields `Result<Value, ModuleError>` chunks. The earlier example incorrectly showed `async fn stream(...) -> Result<Vec<Value>, ModuleError>` (buffered).
+- **D-17** — resolved (verified). `docs/features/acl-system.md` no longer suggests configurability for `caller_id_for_unknown`; `@external` is treated as the canonical literal throughout the doc.
+- **D-18** — resolved. `docs/spec/algorithms.md` Algorithm A09 (`evaluate_acl`) revised: dropped the `priority: Integer` field from the `Rule` struct; dropped the sort + deny-before-allow tiebreak steps; documented insertion-order-first-match-wins as the canonical evaluation order with rationale cross-referenced to this entry. Implementation Notes also updated.
+- **D-26** — resolved. `docs/features/identity-system.md` gained a new "Equality and hashability" subsection: Identity is a value type with structural equality (`id` + `type` + `roles` + `attrs`); hashability is implementation-defined per language (Rust derives `Hash`; Python frozen dataclass with `dict` attrs is not hashable; TypeScript is caller's responsibility).
+
+No SDK behavior changes, no normative `MUST` / `MUST NOT` additions, no schema files touched.

--- a/docs/spec/algorithms.md
+++ b/docs/spec/algorithms.md
@@ -608,8 +608,7 @@ Rule {
   callers: List<String>,   // Pattern list
   targets: List<String>,   // Pattern list
   actions: List<String>,
-  effect: "allow" | "deny",
-  priority: Integer         // Default 0
+  effect: "allow" | "deny"
 }
 ```
 
@@ -634,9 +633,7 @@ Algorithm: evaluate_acl(caller_id, target_id, rules, default_effect)
 
 Steps:
   1. effective_caller ← caller_id ?? "@external"
-  2. Sort rules by priority descending (maintain definition order when priority equal)
-  3. For rules with same priority, deny comes before allow
-  4. For each rule ∈ sorted_rules:
+  2. For each rule ∈ rules (insertion order, first-match-wins):
      a. caller_matched ← false
         For each pattern ∈ rule.callers:
           If match_pattern(pattern, effective_caller) → caller_matched ← true; break
@@ -645,7 +642,7 @@ Steps:
           If match_pattern(pattern, target_id) → target_matched ← true; break
      c. If caller_matched and target_matched:
         → return { effect: rule.effect, matched_rule: rule }
-  5. Return { effect: default_effect, matched_rule: null }
+  3. Return { effect: default_effect, matched_rule: null }
 ```
 
 **Complexity Analysis:**
@@ -653,15 +650,16 @@ Steps:
 | Dimension | Complexity | Description |
 |------|--------|------|
 | Time | O(R * P * M) | R is number of rules, P is average patterns per rule, M is match_pattern complexity |
-| Space | O(R) | Extra space for sorting |
+| Space | O(1) | No sort buffer; rules iterated in stored order |
 
 **Implementation Notes:**
 
 - When `caller_id` is `null`, it **MUST** be replaced with `"@external"`
-- Sorting stability is important: within same priority, deny must come before allow
+- Rules are evaluated in **insertion order** (first-match-wins). Implementations that insert at the front of the list (e.g., `add_rule` prepending) thereby grant newer rules higher precedence — this is the intended convention; do not sort by priority.
 - Missing `actions` field is treated as `["*"]` (matches all operations)
 - Empty `callers` or `targets` array means the rule never matches
 - Modules calling themselves also need ACL checking
+- Rationale for dropping the `priority` field and deny-tiebreak: see `docs/spec/2026-05-decision-log.md` D-18. Insertion-order semantics match all 3 SDK implementations and produce the same results in the common case.
 
 ---
 


### PR DESCRIPTION
Closes #57.

## Summary

A re-audit of `docs/spec/2026-05-decision-log.md` (iter-9, 2026-05-05) found that **5 of the 7 entries originally listed as "Doc-only fixes"** in the 2026-05-02 Resolution status block had never been executed. This PR applies them and updates the Resolution status block to reflect authoritative current state.

| ID | Fix |
|---|---|
| **D-01** | `PROTOCOL_SPEC.md` §5.7: `enum:` → `examples:`; `docs/features/identity-system.md` admonition rewritten |
| **D-07** | `docs/features/call-chain-guard.md:210`: `FrequencyExceededError` → `CallFrequencyExceededError` (matches Error Types table + impl + spec narrative) |
| **D-16** | `docs/features/streaming.md`: Rust producer signature corrected from `async fn stream(...) -> Result<Vec<Value>>` to `fn stream(&self, ...) -> Option<ChunkStream>` |
| **D-18** | `docs/spec/algorithms.md` Algorithm A09: dropped `priority` field + sort + deny-before-allow tiebreak; documented insertion-order-first-match-wins (the algorithm all 3 SDKs actually implement) |
| **D-26** | `docs/features/identity-system.md`: new "Equality and hashability" subsection (structural equality; per-language hashability) |

D-09 and D-17 were silently resolved in earlier rounds; iter-9 addendum notes this.

## Resolution status block update

`docs/spec/2026-05-decision-log.md` lines 789–805 rewritten to reflect:

- **50 items resolved** (consolidated from original list + 2026-05-03 addendum + iter-8 addendum + this iter-9 round).
- **7 items still open**, grouped:
  - Multi-SDK code fix (target v0.21.0): D-03, D-24
  - Single-SDK code fix (deferred / specialized): D-04 (TS codemod), D-20 (Rust doc comment)
  - Minor spec cleanup: D-06
  - Epic / RFC: D-21 + D-22 (Extension `Arc` migration)
- **Follow-through chains** spelled out: D-08 closed via D-49; D-11 via D-42; D-32 via D-56.

Chronological addenda (2026-05-03, iter-8, iter-9) preserved below as history.

## Cross-SDK impact

**None.** All 5 fixes align spec text with what the SDKs already do:

| Fix | Evidence in SDKs |
|---|---|
| D-01 free-form `type` | All 3 SDKs accept any string at construction (no validation) |
| D-07 `CallFrequencyExceededError` | All 3 SDKs implement this name with code `CALL_FREQUENCY_EXCEEDED` |
| D-16 `Option<ChunkStream>` | apcore-rust trait already has this signature |
| D-18 insertion-order ACL | All 3 SDKs iterate `add_rule`-prepended list; none has a `priority` field |
| D-26 structural equality | Already true in all 3 SDKs; this PR documents it |

## Verified locally

- `mkdocs build` → no new warnings (the surviving `migration-v0.18.md` warning is pre-existing and handled by `.github/workflows/deploy-docs.yml` `cp` step at build time)
- `git diff PROTOCOL_SPEC.md` contains no `MUST` / `MUST NOT` additions or removals
- `git diff schemas/` is empty (no schema files touched)
- Each of the 5 fixes verified via grep

## Files

- `PROTOCOL_SPEC.md` — §5.7 Identity type schema (enum → examples)
- `docs/features/call-chain-guard.md` — Contract block error name
- `docs/features/identity-system.md` — admonition + new equality subsection
- `docs/features/streaming.md` — Rust producer example
- `docs/spec/algorithms.md` — Algorithm A09 + Rule struct
- `docs/spec/2026-05-decision-log.md` — Resolution status block rewrite + iter-9 addendum

🤖 Generated with [Claude Code](https://claude.com/claude-code)